### PR TITLE
Add Creekside High School Attendance Dates

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -33,8 +33,8 @@
           </div>
           <div class="about__education-item">
             <div class="school">Creekside High School</div>
-            <div class="degree">Cybersecurity Academy</div>
-            <div class="years">St. Johns County</div>
+            <div class="degree">Cybersecurity Academy &mdash; St. Johns County</div>
+            <div class="years">2017 – 2021</div>
           </div>
         </div>
         <div class="about__honors">


### PR DESCRIPTION
# Add Creekside High School Attendance Dates

## Summary

- Adds `2017 – 2021` dates to the Creekside High School entry to match the date format already used for Furman University and University of Florida
- Moved "St. Johns County" from the `years` field into the `degree` line alongside "Cybersecurity Academy" since that field now holds the dates

## Files Changed

| File | Change |
|---|---|
| `_includes/about.html` | Added `2017 – 2021` to Creekside entry; moved "St. Johns County" to degree line |