### PR TITLE
Add JB Favicon to Portfolio

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/svg+xml" href="{{ '/assets/images/favicon.svg' | relative_url }}">
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 </head>
 <body>

--- a/assets/images/favicon.svg
+++ b/assets/images/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0d1117"/>
+  <text x="16" y="22" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700" text-anchor="middle" fill="#58a6ff">JB</text>
+</svg>


### PR DESCRIPTION
# Add JB Favicon to Portfolio

## Summary
- Added an SVG favicon with "JB" initials using the site's existing dark background (`#0d1117`) and blue accent (`#58a6ff`) colors
- Wired it up in `_layouts/default.html` via a `<link rel="icon">` tag

## Files changed
| File | Change |
|---|---|
| `assets/images/favicon.svg` | New SVG favicon with JB initials |
| `_layouts/default.html` | Added favicon `<link>` tag to `<head>` |