### PR TITLE
Swap FIFA Hero Video for Uninterrupted Gameplay

### DIFF
--- a/assets/js/background.js
+++ b/assets/js/background.js
@@ -4,7 +4,7 @@
   var VIDEOS = [
     'LSPuJ9ggVcA', // Skyrim Special Edition gameplay — Bethesda Softworks
     '4igb7__IrfA', // MW2 campaign gameplay — GameSpot
-    'P821gYMxGiQ'  // FIFA 16 Real Madrid vs Chelsea — Fifizlo
+    'PsOPKZU5ZAA'  // FIFA 16 Gamescom gameplay — PS360HD
   ];
 
   var id = VIDEOS[Math.floor(Math.random() * VIDEOS.length)];


### PR DESCRIPTION
# Swap FIFA Hero Video for Uninterrupted Gameplay

## Summary
- Replaces the FIFA 16 Real Madrid vs Chelsea video (`P821gYMxGiQ`) which contained studio presenter segments with a pure on-pitch Gamescom 2015 capture (`PsOPKZU5ZAA`) that is exclusively gameplay for its full runtime

## Files changed
| File | Change |
|---|---|
| `assets/js/background.js` | Swap FIFA video ID to Gamescom 60fps capture |